### PR TITLE
Make MetaInfo public so it can be used with the result

### DIFF
--- a/Sources/ValidationCore/MetaInfo.swift
+++ b/Sources/ValidationCore/MetaInfo.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 public struct MetaInfo : Codable {
-    let expirationTime : String?
-    let issuedAt : String?
-    let issuer : String?
+    public let expirationTime : String?
+    public let issuedAt : String?
+    public let issuer : String?
     
     init(from cwt: CWT) {
         expirationTime = cwt.exp?.toIso8601DateString()


### PR DESCRIPTION
To be able to display when the certificate expired for the user the variables needs to be public