### PR TITLE
Make CWT properties and EuHealthCert type public

### DIFF
--- a/Sources/ValidationCore/CWT.swift
+++ b/Sources/ValidationCore/CWT.swift
@@ -14,7 +14,7 @@ public struct CWT {
     let iat : UInt64?
     let nbf : UInt64?
     let sub : Data?
-    let euHealthCert : EuHealthCert?
+    public let euHealthCert : EuHealthCert?
     
     enum PayloadKeys : Int {
         case iss = 1
@@ -47,19 +47,19 @@ public struct CWT {
         self.euHealthCert = euHealthCert
     }
     
-    var issuedAt : Date? {
+    public var issuedAt : Date? {
         get {
             return iat?.toDate()
         }
     }
     
-    var notBefore : Date? {
+    public var notBefore : Date? {
         get {
             return nbf?.toDate()
         }
     }
     
-    var expiresAt : Date? {
+    public var expiresAt : Date? {
         get {
             return exp?.toDate()
         }

--- a/Sources/ValidationCore/EuHealthCert.swift
+++ b/Sources/ValidationCore/EuHealthCert.swift
@@ -17,7 +17,7 @@ public struct EuHealthCert : Codable {
     public let recovery: [Recovery]?
     public let tests: [Test]?
     
-    var type : CertType {
+    public var type : CertType {
         get {
             switch self {
             case _ where nil != vaccinations && vaccinations?.count ?? 0 > 0:

--- a/Sources/ValidationCore/Extensions.swift
+++ b/Sources/ValidationCore/Extensions.swift
@@ -25,7 +25,7 @@ extension Data {
     }
 }
 
-extension Date {
+public extension Date {
     func isBefore(_ date: Date) -> Bool {
         return distance(to: date) > 0
     }


### PR DESCRIPTION
Since the CWT is public it's most important fields should also be public for a user.
Additionally the type of the EUHealthCert should also be public because a user might distinguish the display based on the certificate type