### PR TITLE
iOS 12 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "ValidationCore",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v12),
         .macOS(.v11)
     ],
     products: [

--- a/Sources/ValidationCore/CryptoService.swift
+++ b/Sources/ValidationCore/CryptoService.swift
@@ -11,6 +11,7 @@ import LocalAuthentication
 import Security
 import CocoaLumberjackSwift
 
+@available(iOS 13.0, *)
 public struct CryptoService {
     
     public static func generateSymmetricKey(for alias: String, completionHandler : @escaping (ValidationError?)->()) throws {
@@ -133,6 +134,7 @@ protocol GenericPasswordConvertible: CustomStringConvertible {
     var rawRepresentation: Data { get }
 }
 
+@available(iOS 13.0, *)
 extension SymmetricKey: GenericPasswordConvertible {
     public var description: String {
         return "SymmetricKey"

--- a/Sources/ValidationCore/Extensions.swift
+++ b/Sources/ValidationCore/Extensions.swift
@@ -27,10 +27,18 @@ extension Data {
 
 extension Date {
     func isBefore(_ date: Date) -> Bool {
-        return distance(to: date) > 0
+        if #available(iOS 13.0, *) {
+            return distance(to: date) > 0
+        } else {
+            return self < date
+        }
     }
     func isAfter(_ date: Date) -> Bool {
-        return distance(to: date) < 0
+        if #available(iOS 13.0, *) {
+            return distance(to: date) < 0
+        } else {
+            return self > date
+        }
     }
 }
 

--- a/Tests/ValidationCoreTests/TestTrustlistService.swift
+++ b/Tests/ValidationCoreTests/TestTrustlistService.swift
@@ -22,6 +22,10 @@ class TestTrustlistService {
 }
 
 extension TestTrustlistService: TrustlistService {
+    func key(for keyId: Data, cwt: CWT, keyType: CertType, completionHandler: @escaping (Result<SecKey, ValidationError>) -> ()) {
+        return key(for: keyId, keyType: keyType, completionHandler: completionHandler)
+    }
+
     func key(for keyId: Data, keyType: CertType, completionHandler: @escaping (Result<SecKey, ValidationError>) -> ()) {
         guard let encodedCert = encodedCert,
               let cert = Data(base64Encoded: encodedCert) else {

--- a/Tests/ValidationCoreTests/TestUtils.swift
+++ b/Tests/ValidationCoreTests/TestUtils.swift
@@ -94,9 +94,17 @@ extension Vaccination : Equatable {
 
 extension Date {
     func isBefore(_ date: Date) -> Bool {
-        return distance(to: date) >= 0
+        if #available(iOS 13.0, *) {
+            return distance(to: date) >= 0
+        } else {
+            return self < date
+        }
     }
     func isAfter(_ date: Date) -> Bool {
-        return distance(to: date) <= 0
+        if #available(iOS 13.0, *) {
+            return distance(to: date) <= 0
+        } else {
+            return self > date
+        }
     }
 }


### PR DESCRIPTION
CryptoKit is only available on iOS 13. To make ValidationCore usable on even more devices this PR provides very simply support for iOS 12 by not using CryptoKit (and the CryptoService) but instead storing the Trust List data directly in the keychain (as a new alias).
In case the user upgrades the device to iOS 13 the legacy keychain alias is removed from the keychain.