### PR TITLE
fix to accept vaccine doses as Double

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,106 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "ASN1Decoder",
+        "repositoryURL": "https://github.com/filom/ASN1Decoder",
+        "state": {
+          "branch": null,
+          "revision": "65953a42a0f039f53c73e48fd88c02809f7db607",
+          "version": "1.8.0"
+        }
+      },
+      {
+        "package": "base45-swift",
+        "repositoryURL": "https://github.com/ehn-digital-green-development/base45-swift",
+        "state": {
+          "branch": "main",
+          "revision": "db4ccbe535b91d780a08997708c6abf189e98661",
+          "version": null
+        }
+      },
+      {
+        "package": "CocoaLumberjack",
+        "repositoryURL": "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
+        "state": {
+          "branch": null,
+          "revision": "e518eb6e362df327574ba5e04269cd6d29f40aec",
+          "version": "3.7.2"
+        }
+      },
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "682841464136f8c66e04afe5dbd01ab51a3a56f2",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "package": "Gzip",
+        "repositoryURL": "https://github.com/1024jp/GzipSwift",
+        "state": {
+          "branch": null,
+          "revision": "ba0b6cb51cc6202f896e469b87d2889a46b10d1b",
+          "version": "5.1.1"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "af1730dde4e6c0d45bf01b99f8a41713ce536790",
+          "version": "9.2.0"
+        }
+      },
+      {
+        "package": "OHHTTPStubs",
+        "repositoryURL": "https://github.com/AliSoftware/OHHTTPStubs",
+        "state": {
+          "branch": null,
+          "revision": "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+          "version": "9.1.0"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick",
+        "state": {
+          "branch": null,
+          "revision": "8cce6acd38f965f5baa3167b939f86500314022b",
+          "version": "3.1.2"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
+        }
+      },
+      {
+        "package": "SwiftCBOR",
+        "repositoryURL": "https://github.com/eu-digital-green-certificates/SwiftCBOR",
+        "state": {
+          "branch": "master",
+          "revision": "b76024995f6909e4615f943c7a03268fd29778fc",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Sources/ValidationCore/EuHealthCert.swift
+++ b/Sources/ValidationCore/EuHealthCert.swift
@@ -113,12 +113,18 @@ public struct Vaccination : Codable {
         self.medicinialProduct = try container.decode(String.self, forKey: .medicinialProduct).trimmingCharacters(in: .whitespacesAndNewlines)
         self.marketingAuthorizationHolder = try container.decode(String.self, forKey: .marketingAuthorizationHolder).trimmingCharacters(in: .whitespacesAndNewlines)
         self.doseNumber = try container.decode(UInt64.self, forKey: .doseNumber)
+        do {
+            self.doseNumber = try container.decode(UInt64.self, forKey: .doseNumber)
+        } catch DecodingError.typeMismatch {
+            self.doseNumber = try UInt64(container.decode(Double.self, forKey: .doseNumber))
+        }
         guard 1..<10 ~= doseNumber else {
             throw ValidationError.CBOR_DESERIALIZATION_FAILED
         }
-        self.totalDoses = try container.decode(UInt64.self, forKey: .totalDoses)
-        guard 1..<10 ~= totalDoses else {
-            throw ValidationError.CBOR_DESERIALIZATION_FAILED
+        do {
+            self.totalDoses = try container.decode(UInt64.self, forKey: .totalDoses)
+        } catch DecodingError.typeMismatch {
+            self.totalDoses = try UInt64(container.decode(Double.self, forKey: .totalDoses))
         }
         self.vaccinationDate = try container.decode(String.self, forKey: .vaccinationDate)
         guard vaccinationDate.isValidIso8601Date() else {

--- a/Sources/ValidationCore/EuHealthCert.swift
+++ b/Sources/ValidationCore/EuHealthCert.swift
@@ -126,6 +126,8 @@ public struct Vaccination : Codable {
         } catch DecodingError.typeMismatch {
             self.totalDoses = try UInt64(container.decode(Double.self, forKey: .totalDoses))
         }
+        guard 1..<10 ~= totalDoses else {
+             throw ValidationError.CBOR_DESERIALIZATION_FAILED
         self.vaccinationDate = try container.decode(String.self, forKey: .vaccinationDate)
         guard vaccinationDate.isValidIso8601Date() else {
             throw ValidationError.CBOR_DESERIALIZATION_FAILED

--- a/Sources/ValidationCore/EuHealthCert.swift
+++ b/Sources/ValidationCore/EuHealthCert.swift
@@ -128,6 +128,7 @@ public struct Vaccination : Codable {
         }
         guard 1..<10 ~= totalDoses else {
              throw ValidationError.CBOR_DESERIALIZATION_FAILED
+        }
         self.vaccinationDate = try container.decode(String.self, forKey: .vaccinationDate)
         guard vaccinationDate.isValidIso8601Date() else {
             throw ValidationError.CBOR_DESERIALIZATION_FAILED

--- a/Sources/ValidationCore/EuHealthCert.swift
+++ b/Sources/ValidationCore/EuHealthCert.swift
@@ -112,11 +112,25 @@ public struct Vaccination : Codable {
         self.vaccine = try container.decode(String.self, forKey: .vaccine).trimmingCharacters(in: .whitespacesAndNewlines)
         self.medicinialProduct = try container.decode(String.self, forKey: .medicinialProduct).trimmingCharacters(in: .whitespacesAndNewlines)
         self.marketingAuthorizationHolder = try container.decode(String.self, forKey: .marketingAuthorizationHolder).trimmingCharacters(in: .whitespacesAndNewlines)
-        self.doseNumber = try container.decode(UInt64.self, forKey: .doseNumber)
+        //self.doseNumber = try container.decode(UInt64.self, forKey: .doseNumber)
+        
+        do {
+            self.doseNumber = try container.decode(UInt64.self, forKey: .doseNumber)
+        } catch DecodingError.typeMismatch {
+            self.doseNumber = try UInt64(container.decode(Double.self, forKey: .doseNumber))
+        }
+        
         guard 1..<10 ~= doseNumber else {
             throw ValidationError.CBOR_DESERIALIZATION_FAILED
         }
-        self.totalDoses = try container.decode(UInt64.self, forKey: .totalDoses)
+        //self.totalDoses = try container.decode(UInt64.self, forKey: .totalDoses)
+        
+        do {
+            self.totalDoses = try container.decode(UInt64.self, forKey: .totalDoses)
+        } catch DecodingError.typeMismatch {
+            self.totalDoses = try UInt64(container.decode(Double.self, forKey: .totalDoses))
+        }
+        
         guard 1..<10 ~= totalDoses else {
             throw ValidationError.CBOR_DESERIALIZATION_FAILED
         }


### PR DESCRIPTION
Hi,

I just realized at least one certificate that was issued with dose number and total doses as, 1.0 / 2.0 instead of 1 / 2.
Since we are reading as UInt64 I received a CBOR_DESERIALIZATION_FAILED.

:+1: 